### PR TITLE
integrated badtrack into eluthia. Also auto-build

### DIFF
--- a/apps.py
+++ b/apps.py
@@ -5,4 +5,7 @@ config = {
     'fuel': {
         'folder': '../fueltrack',
     },
+    'badtrack-secrets': {
+        'folder': '../badtrack'
+    },
 }

--- a/eluthia/build.py
+++ b/eluthia/build.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 from textwrap import dedent
 from sh import git, pushd, ErrorReturnCode_128
+import subprocess
 
 App = namedtuple('App', ('folder', 'version', 'port'))
 
@@ -56,3 +57,8 @@ if __name__ == '__main__':
         for path, f in flatten_lists(flatten_paths(tree)):
             full_path = (build_folder, package_name, *path)
             f(full_path, *args)
+        
+        # I'm not sure if nginx-conf is meant to be packaged, but it doesn't have a control file so it can't be. This ensures that
+        # it isn't packaged, which would cause an error.
+        if package_name in apps.config.keys():
+            subprocess.run(["dpkg-deb", "--build", f"{build_folder}/{package_name}"],check=True)

--- a/machines/orchid-inca/badtrack-secrets/build.py
+++ b/machines/orchid-inca/badtrack-secrets/build.py
@@ -1,0 +1,49 @@
+from eluthia.decorators import chmod, copy_folder, file, git_clone
+import os
+
+@chmod(0o755)
+@file
+def postinst(package_name, apps):
+    return f'''\
+        #!/bin/bash
+        # Set ownership of secrets.env to badtrackuser
+        getent passwd badtrackuser > /dev/null || sudo useradd -r -s /bin/false badtrackuser
+        chown -R badtrackuser:badtrackuser \"/var/lib/badtrack/secrets.env\"
+    '''
+
+@file
+def control(package_name, apps):
+    return f'''\
+        Package: {package_name}
+        Version: {apps[package_name].version}
+        Section: custom
+        Priority: optional
+        Architecture: all
+        Essential: no
+        #Installed-Size: 1024
+        Maintainer: Your Name <your-email@example.com>
+        Description: Badtracksecrets is a sample package
+    '''
+
+@chmod(0o600)
+@file
+def secrets(package_name, apps):
+    return f'''\
+        EMAIL_USER = {os.environ['EMAIL_USER']}
+        EMAIL_PASSWORD = {os.environ['EMAIL_PASSWORD']}
+    '''
+
+def get_package_tree(package_name, apps):
+    return {
+        'DEBIAN': {
+            'postinst': postinst,
+            'control': control,
+        },
+        'var': {
+            'lib': {
+                'badtrack': {
+                    'secrets.env': secrets
+                }
+            }
+        }
+    }

--- a/machines/orchid-inca/badtrack/build.py
+++ b/machines/orchid-inca/badtrack/build.py
@@ -1,16 +1,21 @@
 from eluthia.decorators import chmod, copy_folder, file, git_clone
+import os
+
+is_test = 'TEST_MODE' in os.environ
 
 @chmod(0o755)
 @file
 def postinst(package_name, apps):
     return f'''\
         #!/bin/bash
+        getent passwd badtrackuser > /dev/null || sudo useradd -r -s /bin/false badtrackuser
+        chown -R badtrackuser:badtrackuser \"/var/lib/badtrack/\"
         # Reload the systemd daemon to recognize the new service file
         systemctl daemon-reload
 
         # Enable and start the service
         systemctl enable {package_name}
-        systemctl start {package_name}
+        systemctl restart {package_name}
     '''
 
 @file
@@ -18,11 +23,12 @@ def control(package_name, apps):
     return f'''\
         Package: {package_name}
         Version: {apps[package_name].version}
+        Depends: badtrack-secrets
         Section: custom
         Priority: optional
         Architecture: all
         Essential: no
-        # Installed-Size: 1024
+        #Installed-Size: 1024
         Maintainer: Your Name <your-email@example.com>
         Description: Badtrack is a sample package
     '''
@@ -39,9 +45,21 @@ def systemd_service(package_name, apps):
         WorkingDirectory=/usr/local/bin/badtrack
         ExecStart=/usr/bin/python3 /usr/local/bin/badtrack/main.py
         Environment=HISTORY_FOLDER=/var/lib/badtrack/history
+        Environment=CACHE_FOLDER=/var/lib/badtrack/cache
+        #This is to allow for testing.
+        Environment=EMAIL_HOST={'localhost' if is_test else 'relay.mailbaby.net'}
+        Environment=EMAIL_PORT={'1025' if is_test else '465'}
+        Environment=EMAIL_FROM=sender@obsi.com.au
+        Environment=EMAIL_TO={'yannstaggl@gmail.com' if is_test else 'robinchew@gmail.com'}
+        EnvironmentFile=/var/lib/badtrack/secrets.env
         [Install]
         WantedBy=multi-user.target
     '''
+
+# I think it'd be better if this was somewhere else and then could be imported in, but I wasn't sure where to put it. 
+def blank_folder(full_path, package_name, apps):
+    os.makedirs(os.path.join(*full_path), exist_ok=True)
+    return
 
 def get_package_tree(package_name, apps):
     return {
@@ -59,8 +77,16 @@ def get_package_tree(package_name, apps):
         'usr': {
             'local': {
                 'bin': {
-                    'badtrack': git_clone(apps[package_name].folder),
+                    'badtrack': copy_folder('/home/ystaggl/Workspace/badtrack') if is_test else git_clone(apps[package_name].folder),
                 }
             },
         },
+        'var':{
+            'lib':{
+                'badtrack': {
+                    'history': blank_folder,
+                    'cache': blank_folder,
+                }
+            }
+        }
     }


### PR DESCRIPTION
Integrated badtrack (and badtrack-secrets) eluthia. Renamed badtracksecrets to badtrack-secrets. Added dpkg-deb --build functionality to eluthia. Also added checks for if badtrack is being tested (checks whether the TEST_MODE environment variable is set, any value will trigger testing mode).

The credentials for emails are set by running EMAIL_USER=. EMAIL_PASSWORD=. (other environment variables) ./eluthia/build.py